### PR TITLE
Tweaked vSphere networks, etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-commit 15fe83284dcef730ea01caddef2f26c9985ea386
+commit 2c4658990f44e1a35ab6cdaec66dbf9b02d89fd4
 Author: Larry Smith Jr <mrlesmithjr@gmail.com>
 Date:   Sat Mar 28 17:42:33 2020 -0400
 

--- a/examples/configs.yml
+++ b/examples/configs.yml
@@ -8,6 +8,7 @@ project_name: example
 required_version: 0.12.0
 
 # Define backends
+# Currently only local and limited Consul support
 backends:
   local:
     path: terraform.tfstate
@@ -79,9 +80,9 @@ providers:
           module: root
           virtual_networks:
             example-net:
+              create: true
               address_space:
                 - 10.0.0.0/16
-              create: true
               subnets:
                 - 10.0.1.0/24
                 - 10.0.2.0/24
@@ -190,6 +191,7 @@ providers:
     resources:
       datacenters:
         example-dc:
+          create: true
           clusters:
             example-cluster:
               create: true
@@ -212,16 +214,24 @@ providers:
                 example-vm-from-template:
                   count: 1
                   memory: 2048
-                  network: example-pg
+                  # Need a way to decide how to select either data.vsphere_network
+                  # or other
+                  network: example-network
                   num_cpus: 1
                   tags:
                     - example-vsphere
                   template: ubuntu-18-04-x64
-          create: true
           module: root
+          # Define existing networks to consume, not create
+          networks:
+            - example-network
+          # Define existing templates to consume, not create
           templates:
             - ubuntu-16-04-x64
             - ubuntu-18-04-x64
+          # Define virtual switches to create
+          # If false, they will just be skipped
+          # Only works with hosts that are created
           virtual_switches:
             example-switch:
               create: true
@@ -234,11 +244,14 @@ providers:
               standby_nics:
                 - vmnic1
               teaming_policy: loadbalance_srcid
+              # Define port groups to create
+              # If false, they will just be skipped
               port_groups:
                 example-pg:
                   create: true
       tag_categories:
         example-category:
+          create: true
           associable_types:
             - ClusterComputeResource
             - Datacenter
@@ -246,7 +259,6 @@ providers:
             - HostSystem
             - VirtualMachine
           cardinality: SINGLE
-          create: true
           module: root
           tags:
             - example-vsphere

--- a/examples/example_builds/example/root/resources.tf
+++ b/examples/example_builds/example/root/resources.tf
@@ -135,6 +135,7 @@ resource "vsphere_host_port_group" "example_pg" {
   host_system_id      = vsphere_host.example_esxi_01.id
   virtual_switch_name = vsphere_host_virtual_switch.example_switch.name
 }
+
 # Resource vSphere virtual machine
 resource "vsphere_virtual_machine" "example_vm" {
   count            = 1
@@ -148,6 +149,7 @@ resource "vsphere_virtual_machine" "example_vm" {
 
   tags = ["vsphere_tag.example_vsphere.id"]
 }
+
 # Resource vSphere virtual machine
 resource "vsphere_virtual_machine" "example_vm_from_template" {
   count            = 1
@@ -158,7 +160,7 @@ resource "vsphere_virtual_machine" "example_vm_from_template" {
   guest_id         = data.vsphere_virtual_machine.ubuntu_18_04_x64.guest_id
   scsi_type        = data.vsphere_virtual_machine.ubuntu_18_04_x64.scsi_type
   network_interface {
-    network_id   = vsphere_host_port_group.example_pg.id
+    network_id   = data.vsphere_network.example_network.id
     adapter_type = data.vsphere_virtual_machine.ubuntu_18_04_x64.network_interface_types[0]
   }
   disk {
@@ -172,6 +174,11 @@ resource "vsphere_virtual_machine" "example_vm_from_template" {
   }
 
   tags = ["vsphere_tag.example_vsphere.id"]
+}
+# Data vSphere network
+data "vsphere_network" "example_network" {
+  name          = "example-network"
+  datacenter_id = vsphere_datacenter.example_dc.id
 }
 # Resource vSphere tag category
 resource "vsphere_tag_category" "example_category" {

--- a/terraform_builder/specs/templates/providers/vsphere/resources/vsphere_compute_cluster.j2
+++ b/terraform_builder/specs/templates/providers/vsphere/resources/vsphere_compute_cluster.j2
@@ -3,15 +3,25 @@
 # Resource {{ provider }} compute cluster
 resource "vsphere_compute_cluster" "{{ cluster|replace('-','_') }}" {
   name          = "{{ cluster }}"
-{%-  if dc_config.create %}
+{%-      if dc_config.create %}
   datacenter_id = vsphere_datacenter.{{ dc|replace('-','_') }}.id
-{%-  else %}
+{%-      else %}
   datacenter_id = data.vsphere_datacenter.{{ dc|replace('-','_') }}.id
-{%-  endif %}
+{%-      endif %}
   # host_system_ids     = ["${data.vsphere_host.hosts.*.id}"]
   drs_enabled          = {{ cluster_config.drs_enabled|lower }}
   drs_automation_level = "{{ cluster_config.drs_automation_level }}"
   ha_enabled           = {{ cluster_config.ha_enabled|lower }}
+}
+{%-    else %}
+# Data {{ provider }} compute cluster
+data "vsphere_compute_cluster" "{{ cluster|replace('-','_') }}" {
+  name          = "{{ cluster }}"
+{%-      if dc_config.create %}
+  datacenter_id = vsphere_datacenter.{{ dc|replace('-','_') }}.id
+{%-      else %}
+  datacenter_id = data.vsphere_datacenter.{{ dc|replace('-','_') }}.id
+{%-      endif %}
 }
 {%-    endif %}
 {%-    if cluster_config.hosts %}

--- a/terraform_builder/specs/templates/providers/vsphere/resources/vsphere_datacenter.j2
+++ b/terraform_builder/specs/templates/providers/vsphere/resources/vsphere_datacenter.j2
@@ -17,5 +17,8 @@ data "vsphere_datacenter" "{{ dc|replace('-','_') }}" {
 {%-      if dc_config.clusters %}
 {%-        include 'providers/vsphere/resources/vsphere_compute_cluster.j2' %}
 {%-      endif %}
+{%-      if dc_config.networks %}
+{%-        include 'providers/vsphere/resources/vsphere_network.j2' %}
+{%-      endif %}
 {%-    endif %}
 {%-  endfor %}

--- a/terraform_builder/specs/templates/providers/vsphere/resources/vsphere_host.j2
+++ b/terraform_builder/specs/templates/providers/vsphere/resources/vsphere_host.j2
@@ -1,5 +1,6 @@
 {%-  for host, host_config in cluster_config.hosts.items() %}
-{%-    if host_config.create %}
+{%-    if cluster_config.create %}
+{%-      if host_config.create %}
 # Resource {{ provider }} host
 resource "vsphere_host" "{{ host|replace('-','_') }}" {
   hostname = "{{ host_config.hostname }}"
@@ -7,18 +8,19 @@ resource "vsphere_host" "{{ host|replace('-','_') }}" {
   password = var.vsphere_host_password
   cluster  = vsphere_compute_cluster.{{ cluster|replace('-','_') }}.id
 }
-{%-    else %}
+{%-      else %}
 # Data {{ provider }} host
 data "vsphere_host" "{{ host|replace('-','_') }}" {
   name          = "{{ host }}"
-{%-      if dc_config.create %}
+{%-        if dc_config.create %}
   datacenter_id = vsphere_datacenter.{{ dc|replace('-','_') }}.id
-{%-      else %}
+{%-        else %}
   datacenter_id = data.vsphere_datacenter.{{ dc|replace('-','_') }}.id
-{%-      endif %}
+{%-        endif %}
 }
-{%-    endif %}
-{%-    if dc_config.virtual_switches %}
-{%-      include 'providers/vsphere/resources/vsphere_host_virtual_switch.j2' %}
+{%-      endif %}
+{%-      if dc_config.virtual_switches %}
+{%-        include 'providers/vsphere/resources/vsphere_host_virtual_switch.j2' %}
+{%-      endif %}
 {%-    endif %}
 {%-  endfor %}

--- a/terraform_builder/specs/templates/providers/vsphere/resources/vsphere_network.j2
+++ b/terraform_builder/specs/templates/providers/vsphere/resources/vsphere_network.j2
@@ -1,0 +1,11 @@
+{%-  for network in dc_config.networks %}
+# Data {{ provider }} network
+data "vsphere_network" "{{ network|replace('-','_') }}" {
+  name          = "{{ network }}"
+{%-    if dc_config.create %}
+  datacenter_id = vsphere_datacenter.{{ dc|replace('-','_') }}.id
+{%-    else %}
+  datacenter_id = data.vsphere_datacenter.{{ dc|replace('-','_') }}.id
+{%-    endif %}
+}
+{%-  endfor %}

--- a/terraform_builder/specs/templates/providers/vsphere/resources/vsphere_virtual_machine.j2
+++ b/terraform_builder/specs/templates/providers/vsphere/resources/vsphere_virtual_machine.j2
@@ -1,6 +1,11 @@
 {%-  for vm, vm_config in cluster_config.vms.items() %}
 {%-    set memory = (vm_config.memory|default(1024)/1024)|round|int|string %}
 {%-    set cpus = (vm_config.num_cpus)|default(1)|string %}
+{%-    if vm_config.network in dc_config.networks %}
+{%       set network_id = 'data.vsphere_network.'+vm_config.network|replace('-','_')+'.id' %}
+{%-    else %}
+{%       set network_id = 'vsphere_host_port_group.'+vm_config.network|replace('-','_')+'.id' %}
+{%-    endif %}
 # Resource {{ provider }} virtual machine
 resource "vsphere_virtual_machine" "{{ vm.split('.')[0]|replace('-','_') }}" {
   count            = {{ vm_config.count|default(1) }}
@@ -16,7 +21,7 @@ resource "vsphere_virtual_machine" "{{ vm.split('.')[0]|replace('-','_') }}" {
   guest_id         = data.vsphere_virtual_machine.{{ vm_config.template|replace('-','_') }}.guest_id
   scsi_type        = data.vsphere_virtual_machine.{{ vm_config.template|replace('-','_') }}.scsi_type
   network_interface {
-    network_id   = vsphere_host_port_group.{{ vm_config.network|replace('-','_') }}.id
+    network_id   = {{ network_id }}
     adapter_type = data.vsphere_virtual_machine.{{ vm_config.template|replace('-','_') }}.network_interface_types[0]
   }
   disk {
@@ -30,7 +35,7 @@ resource "vsphere_virtual_machine" "{{ vm.split('.')[0]|replace('-','_') }}" {
   }
 {%-    else %}
   network_interface {
-    network_id = vsphere_host_port_group.{{ vm_config.network|replace('-','_') }}.id
+    network_id = {{ network_id }}
   }
 {%-    endif %}
 {%-    if vm_config.tags %}


### PR DESCRIPTION
vSphere networking was only working if a vSwitch and portgroup were
created. Consuming existing networks did not work. This has been added
and needs a bit more testing to ensure most scenarios are validated
based on current functionality.

Closes #24