### PR TITLE
Moved VMs from underneath projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,36 @@
-commit 2c4658990f44e1a35ab6cdaec66dbf9b02d89fd4
+commit 0e0a0878064ff61418bec20208c57eef8b91b22e
+Author: Larry Smith Jr <mrlesmithjr@gmail.com>
+Date:   Sun Mar 29 13:25:58 2020 -0400
+
+    Added initial DigitalOcean firewall support
+    
+    This is just the beginning portion. Will add more functionality later
+    Closes #26
+
+commit 50ce6acab86154d5a530afa6dfc97bcbdc208cc9
+Author: Larry Smith Jr <mrlesmithjr@gmail.com>
+Date:   Sat Mar 28 23:13:43 2020 -0400
+
+    Tweaked vSphere networks, etc.
+    
+    vSphere networking was only working if a vSwitch and portgroup were
+    created. Consuming existing networks did not work. This has been added
+    and needs a bit more testing to ensure most scenarios are validated
+    based on current functionality.
+    
+    Closes #24
+
+commit 8878330fb5beca01be2b9ea009d13c78edefb6cc
+Author: Larry Smith Jr <mrlesmithjr@gmail.com>
+Date:   Sat Mar 28 17:42:33 2020 -0400
+
+    Changed modules to include environment as part of their name
+    
+    This will ensure that there is not any confusion over which environment.
+    We also still include the environment var as part of the module.
+    But this will ensure we follow best practices.
+
+commit 15fe83284dcef730ea01caddef2f26c9985ea386
 Author: Larry Smith Jr <mrlesmithjr@gmail.com>
 Date:   Sat Mar 28 17:42:33 2020 -0400
 

--- a/examples/configs.yml
+++ b/examples/configs.yml
@@ -149,11 +149,13 @@ providers:
   DigitalOcean:
     resources:
       firewalls:
-        # droplets will select firewall rules by name. However, the firewall
-        # rule module also needs to match the module for the project in which the
-        # VM resides within. Otherwise, they will not map.
+        # droplets will select firewall rules by name. Under modules, add any
+        # modules which you'd like the firewall available within. This allows
+        # us to define a single firewall, and make it available across modules.
+        # Therefore, reducing the number of firewalls to configure.
         default:
-          module: root
+          modules:
+            - root
           name: default-server-rules
           rules:
             - protocol: tcp
@@ -175,7 +177,8 @@ providers:
             - default-firewall
         web:
           create: true
-          module: root
+          modules:
+            - root
           name: web-server-rules
           rules:
             - protocol: tcp
@@ -209,15 +212,19 @@ providers:
           purpose: Just to demonstrate an example project
           tags:
             - example-digitalocean
-          vms:
-            example-vm:
-              count: 1
-              firewall: default
-              image: ubuntu-18-04-x64
-              memory: 1024
-              num_cpus: 1
-              tags:
-                - example-digitalocean
+      vms:
+        # Define firewall to apply, if applicable.
+        # Define project to add VM to, if applicable.
+        example-vm:
+          count: 1
+          firewall: default
+          image: ubuntu-18-04-x64
+          memory: 1024
+          module: root
+          project: example
+          num_cpus: 1
+          tags:
+            - example-digitalocean
     variables:
       do_api_endpoint:
         type: string

--- a/examples/example_builds/example/README.md
+++ b/examples/example_builds/example/README.md
@@ -143,7 +143,8 @@ DigitalOcean:
   resources:
     firewalls:
       default:
-        module: root
+        modules:
+        - root
         name: default-server-rules
         rules:
         - direction: inbound
@@ -171,7 +172,8 @@ DigitalOcean:
         - default-firewall
       web:
         create: true
-        module: root
+        modules:
+        - root
         name: web-server-rules
         rules:
         - direction: inbound
@@ -209,15 +211,17 @@ DigitalOcean:
         purpose: Just to demonstrate an example project
         tags:
         - example-digitalocean
-        vms:
-          example-vm:
-            count: 1
-            firewall: default
-            image: ubuntu-18-04-x64
-            memory: 1024
-            num_cpus: 1
-            tags:
-            - example-digitalocean
+    vms:
+      example-vm:
+        count: 1
+        firewall: default
+        image: ubuntu-18-04-x64
+        memory: 1024
+        module: root
+        num_cpus: 1
+        project: example
+        tags:
+        - example-digitalocean
   variables:
     do_api_endpoint:
       default: https://api.digitalocean.com

--- a/examples/example_builds/example/root/resources.tf
+++ b/examples/example_builds/example/root/resources.tf
@@ -120,6 +120,16 @@ resource "digitalocean_firewall" "web" {
     destination_addresses = ["0.0.0.0/0", "::/0"]
   }
 }
+# Resource DigitalOcean virtual machine
+resource "digitalocean_droplet" "example_vm" {
+  count    = 1
+  name     = format("example-vm-%02s-%s", count.index + 1, substr(var.environment, 0, 4))
+  image    = "ubuntu-18-04-x64"
+  region   = var.do_region
+  size     = "s-1vcpu-1gb"
+  ssh_keys = var.do_ssh_keys
+  tags     = [digitalocean_tag.example_digitalocean.id]
+}
 # Resource DigitalOcean project
 resource "digitalocean_project" "example" {
   name        = format("example-%s", substr(var.environment, 0, 4))
@@ -135,16 +145,6 @@ resource "digitalocean_domain" "example_org" {
 # Resource DigitalOcean tag
 resource "digitalocean_tag" "example_digitalocean" {
   name = "example-digitalocean"
-}
-# Resource DigitalOcean virtual machine
-resource "digitalocean_droplet" "example_vm" {
-  count    = 1
-  name     = format("example-vm-%02s-%s", count.index + 1, substr(var.environment, 0, 4))
-  image    = "ubuntu-18-04-x64"
-  region   = var.do_region
-  size     = "s-1vcpu-1gb"
-  ssh_keys = var.do_ssh_keys
-  tags     = [digitalocean_tag.example_digitalocean.id]
 }
 # Obtain list of project resources as local and use
 locals {

--- a/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean.j2
+++ b/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean.j2
@@ -1,24 +1,9 @@
 {%- if provider_config.resources.firewalls %}
 {%-   include 'providers/digitalocean/resources/digitalocean_firewall.j2' %}
 {%- endif %}
-{%-  if provider_config.resources.projects %}
-{%-    for proj, proj_config in provider_config.resources.projects.items() %}
-{%-      if proj_config.module == module %}
-{%-        set project_resources = [] %}
-{%-        include 'providers/digitalocean/resources/digitalocean_project.j2' %}
-{%-        if proj_config.domains %}
-{%-          include 'providers/digitalocean/resources/digitalocean_domain.j2' %}
-{%-        endif %}
-{%-        if proj_config.tags %}
-{%-          include 'providers/digitalocean/resources/digitalocean_tag.j2' %}
-{%-        endif %}
-{%-        if proj_config.vms %}
-{%-          include 'providers/digitalocean/resources/digitalocean_droplet.j2' %}
-{%-        endif %}
-# Obtain list of project resources as local and use
-locals {
-  project_resources = {{ project_resources|replace('\'','') }}
-}
-{%-      endif %}
-{%-    endfor %}
-{%-  endif %}
+{%- if provider_config.resources.vms %}
+{%-   include 'providers/digitalocean/resources/digitalocean_droplet.j2' %}
+{%- endif %}
+{%- if provider_config.resources.projects %}
+{%-   include 'providers/digitalocean/resources/digitalocean_project.j2' %}
+{%- endif %}

--- a/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_domain.j2
+++ b/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_domain.j2
@@ -1,14 +1,14 @@
-{%-  for domain, domain_config in proj_config.domains.items() %}
-{%-    if domain_config.create %}
+{%- for domain, domain_config in proj_config.domains.items() %}
+{%-   if domain_config.create %}
 # Resource {{ provider }} domain
 resource "digitalocean_domain" "{{ domain|replace('-','_')|replace('.','_') }}" {
   name = "{{ domain }}"
 }
-{%-      set _ = project_resources.append('digitalocean_domain.'+domain|replace('-','_')|replace('.','_')+'.urn') %}
-{%-    else %}
+{%-     set _ = project_resources.append('digitalocean_domain.'+domain|replace('-','_')|replace('.','_')+'.urn') %}
+{%-   else %}
 # Data {{ provider }} domain
 data "digitalocean_domain" "{{ domain|replace('-','_')|replace('.','_') }}" {
   name = "{{ domain }}"
 }
-{%-    endif %}
-{%-  endfor %}
+{%-   endif %}
+{%- endfor %}

--- a/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_droplet.j2
+++ b/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_droplet.j2
@@ -1,4 +1,5 @@
-{%-  for vm, vm_config in proj_config.vms.items() %}
+{%- for vm, vm_config in provider_config.resources.vms.items() %}
+{%-   if vm_config.module == module %}
 {%-    set memory = (vm_config.memory|default(1024)/1024)|round|int|string %}
 {%-    set cpus = (vm_config.num_cpus)|default(1)|string %}
 # Resource {{ provider }} virtual machine
@@ -18,5 +19,5 @@ resource "digitalocean_droplet" "{{ vm.split('.')[0]|replace('-','_') }}" {
   tags     = {{ tags|replace('\'', '') }}
 {%-    endif %}
 }
-{%-      set _ = project_resources.append('digitalocean_droplet.'+vm.split('.')[0]|replace('-','_')+'.*.urn') %}
-{%-  endfor %}
+{%-   endif %}
+{%- endfor %}

--- a/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_firewall.j2
+++ b/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_firewall.j2
@@ -9,17 +9,13 @@
 {%-       endfor %}
 {%-     endif %}
 {%-   endif %}
-{%-   if fw_config.module == module %}
+{%-   if module in fw_config.modules %}
 {%-     set fw_resources = [] %}
-{%-     if provider_config.resources.projects %}
-{%-       for proj, proj_config in provider_config.resources.projects.items() %}
-{%-         if proj_config.module == module %}
-{%-           if proj_config.vms %}
-{%-             for vm, vm_config in proj_config.vms.items() %}
-{%-               if vm_config.firewall and vm_config.firewall == fw %}
-{%-                 set _ = fw_resources.append('digitalocean_droplet.'+vm|replace('-','_')+'.*.id') %}
-{%-               endif %}
-{%-             endfor %}
+{%-     if provider_config.resources.vms %}
+{%-       for vm, vm_config in provider_config.resources.vms.items() %}
+{%-         if vm_config.module == module %}
+{%-           if vm_config.firewall and vm_config.firewall == fw %}
+{%-             set _ = fw_resources.append('digitalocean_droplet.'+vm|replace('-','_')+'.*.id') %}
 {%-           endif %}
 {%-         endif %}
 {%-       endfor %}

--- a/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_project.j2
+++ b/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_project.j2
@@ -1,4 +1,7 @@
-{%-  if proj_config.create %}
+{%- for proj, proj_config in provider_config.resources.projects.items() %}
+{%-   if proj_config.module == module %}
+{%-     set project_resources = [] %}
+{%-     if proj_config.create %}
 # Resource {{ provider }} project
 resource "digitalocean_project" "{{ proj|replace('-','_') }}" {
   name        = format("{{ proj }}-%s", substr(var.environment, 0, 4))
@@ -7,9 +10,30 @@ resource "digitalocean_project" "{{ proj|replace('-','_') }}" {
   environment = var.environment
   resources   = [for resource in flatten(local.project_resources) : resource]
 }
-{%-  else %}
+{%-     else %}
 # Data {{ provider }} project
 data "digitalocean_project" "{{ proj|replace('-','_') }}" {
   name        = format("{{ proj }}-%s", substr(var.environment, 0, 4))
 }
-{%-  endif %}
+{%-     endif %}
+{%-     if proj_config.domains %}
+{%-       include 'providers/digitalocean/resources/digitalocean_domain.j2' %}
+{%-     endif %}
+{%-     if proj_config.tags %}
+{%-       include 'providers/digitalocean/resources/digitalocean_tag.j2' %}
+{%-     endif %}
+{%-     if provider_config.resources.vms %}
+{%-       for vm, vm_config in provider_config.resources.vms.items() %}
+{%-         if vm_config.module == module %}
+{%-           if vm_config.project and vm_config.project == proj %}
+{%-             set _ = project_resources.append('digitalocean_droplet.'+vm.split('.')[0]|replace('-','_')+'.*.urn') %}
+{%-           endif %}
+{%-         endif %}
+{%-       endfor %}
+{%-     endif %}
+# Obtain list of project resources as local and use
+locals {
+  project_resources = {{ project_resources|replace('\'','') }}
+}
+{%-   endif %}
+{%- endfor %}

--- a/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_tag.j2
+++ b/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_tag.j2
@@ -1,6 +1,6 @@
 {%- if fw_config and fw_config.tags %}
 {%-   for tag in fw_config.tags %}
-{%-     if fw_config.module == module %}
+{%-     if module in fw_config.modules %}
 # Resource {{ provider }} tag
 resource "digitalocean_tag" "{{ tag|replace('-','_') }}" {
   name = "{{ tag }}"


### PR DESCRIPTION
Because DigitalOcean does not require anything to be in place to start
creating VMs, we have moved VMs out to their own structure under
resources. This also affected how firewalls, etc. are applied to VMs.
So, some additional tweaks were required to accomplish this.

There is still an issue with tags between modules if a VM moves. Will
address this in another issue.

Closes #27