### PR TITLE
Fixed DigitalOcean tags

### DIFF
--- a/examples/configs.yml
+++ b/examples/configs.yml
@@ -212,6 +212,15 @@ providers:
           purpose: Just to demonstrate an example project
           tags:
             - example-digitalocean
+      # Define tags that need to be available across all modules. Then you can
+      # define the applicable tags to the respective resources. An additional
+      # tag will be created that will append each environment to the tag name.
+      # Ex. example-digitalocean-development, example-digitalocean-production,
+      # example-digitalocean-staging. Resources with tags defined will also be
+      # add to the tag with the environment as well.
+      tags:
+        - default-firewall
+        - example-digitalocean
       vms:
         # Define firewall to apply, if applicable.
         # Define project to add VM to, if applicable.

--- a/examples/example_builds/example/README.md
+++ b/examples/example_builds/example/README.md
@@ -211,6 +211,9 @@ DigitalOcean:
         purpose: Just to demonstrate an example project
         tags:
         - example-digitalocean
+    tags:
+    - default-firewall
+    - example-digitalocean
     vms:
       example-vm:
         count: 1

--- a/examples/example_builds/example/modules/network/resources.tf
+++ b/examples/example_builds/example/modules/network/resources.tf
@@ -1,1 +1,17 @@
 # Generated using https://github.com/mrlesmithjr/terraform-builder
+# Resource DigitalOcean tag
+resource "digitalocean_tag" "default_firewall" {
+  name = "default-firewall"
+}
+# Resource DigitalOcean tag
+resource "digitalocean_tag" "default_firewall_env" {
+  name = format("default-firewall-%s", var.environment)
+}
+# Resource DigitalOcean tag
+resource "digitalocean_tag" "example_digitalocean" {
+  name = "example-digitalocean"
+}
+# Resource DigitalOcean tag
+resource "digitalocean_tag" "example_digitalocean_env" {
+  name = format("example-digitalocean-%s", var.environment)
+}

--- a/examples/example_builds/example/modules/services/resources.tf
+++ b/examples/example_builds/example/modules/services/resources.tf
@@ -1,1 +1,17 @@
 # Generated using https://github.com/mrlesmithjr/terraform-builder
+# Resource DigitalOcean tag
+resource "digitalocean_tag" "default_firewall" {
+  name = "default-firewall"
+}
+# Resource DigitalOcean tag
+resource "digitalocean_tag" "default_firewall_env" {
+  name = format("default-firewall-%s", var.environment)
+}
+# Resource DigitalOcean tag
+resource "digitalocean_tag" "example_digitalocean" {
+  name = "example-digitalocean"
+}
+# Resource DigitalOcean tag
+resource "digitalocean_tag" "example_digitalocean_env" {
+  name = format("example-digitalocean-%s", var.environment)
+}

--- a/examples/example_builds/example/root/resources.tf
+++ b/examples/example_builds/example/root/resources.tf
@@ -61,15 +61,11 @@ resource "azurerm_virtual_machine" "example_vm_root" {
   }
   tags = {"environment": "${var.environment}"}
 }
-# Resource DigitalOcean tag
-resource "digitalocean_tag" "default_firewall" {
-  name = "default-firewall"
-}
 # Resource DigitalOcean firewall
 resource "digitalocean_firewall" "default" {
   name = format("default-server-rules-%s", var.environment)
   droplet_ids = concat(digitalocean_droplet.example_vm.*.id)
-  tags     = [digitalocean_tag.default_firewall.id]
+  tags     = [digitalocean_tag.default_firewall.id, digitalocean_tag.default_firewall_env.id]
   inbound_rule {
     protocol         = "tcp"
     port_range       = "22"
@@ -120,6 +116,22 @@ resource "digitalocean_firewall" "web" {
     destination_addresses = ["0.0.0.0/0", "::/0"]
   }
 }
+# Resource DigitalOcean tag
+resource "digitalocean_tag" "default_firewall" {
+  name = "default-firewall"
+}
+# Resource DigitalOcean tag
+resource "digitalocean_tag" "default_firewall_env" {
+  name = format("default-firewall-%s", var.environment)
+}
+# Resource DigitalOcean tag
+resource "digitalocean_tag" "example_digitalocean" {
+  name = "example-digitalocean"
+}
+# Resource DigitalOcean tag
+resource "digitalocean_tag" "example_digitalocean_env" {
+  name = format("example-digitalocean-%s", var.environment)
+}
 # Resource DigitalOcean virtual machine
 resource "digitalocean_droplet" "example_vm" {
   count    = 1
@@ -128,7 +140,7 @@ resource "digitalocean_droplet" "example_vm" {
   region   = var.do_region
   size     = "s-1vcpu-1gb"
   ssh_keys = var.do_ssh_keys
-  tags     = [digitalocean_tag.example_digitalocean.id]
+  tags     = [digitalocean_tag.example_digitalocean.id, digitalocean_tag.example_digitalocean_env.id]
 }
 # Resource DigitalOcean project
 resource "digitalocean_project" "example" {
@@ -141,10 +153,6 @@ resource "digitalocean_project" "example" {
 # Resource DigitalOcean domain
 resource "digitalocean_domain" "example_org" {
   name = "example.org"
-}
-# Resource DigitalOcean tag
-resource "digitalocean_tag" "example_digitalocean" {
-  name = "example-digitalocean"
 }
 # Obtain list of project resources as local and use
 locals {

--- a/terraform_builder/specs/templates/modules/resources.tf.j2
+++ b/terraform_builder/specs/templates/modules/resources.tf.j2
@@ -4,6 +4,7 @@
 {%-      if provider == 'AzureRM' %}
 {%-        include 'providers/azurerm/resources/azurerm.j2' %}
 {%-     elif provider == 'DigitalOcean' %}
+{%-        set do_tags = [] %}
 {%-        include 'providers/digitalocean/resources/digitalocean.j2' %}
 {%-     elif provider == 'vSphere' %}
 {%-        include 'providers/vsphere/resources/vsphere.j2' %}

--- a/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean.j2
+++ b/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean.j2
@@ -1,6 +1,9 @@
 {%- if provider_config.resources.firewalls %}
 {%-   include 'providers/digitalocean/resources/digitalocean_firewall.j2' %}
 {%- endif %}
+{%- if provider_config.resources.tags %}
+{%-   include 'providers/digitalocean/resources/digitalocean_tag.j2' %}
+{%- endif %}
 {%- if provider_config.resources.vms %}
 {%-   include 'providers/digitalocean/resources/digitalocean_droplet.j2' %}
 {%- endif %}

--- a/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_droplet.j2
+++ b/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_droplet.j2
@@ -15,6 +15,8 @@ resource "digitalocean_droplet" "{{ vm.split('.')[0]|replace('-','_') }}" {
 {%-      for tag in vm_config.tags %}
 {%-        set tag_id = 'digitalocean_tag.'+tag|replace('-','_')+'.id' %}
 {%-        set _ = tags.append(tag_id) %}
+{%-        set tag_id_env = 'digitalocean_tag.'+tag|replace('-','_')+'_env.id' %}
+{%-        set _ = tags.append(tag_id_env) %}
 {%-      endfor %}
   tags     = {{ tags|replace('\'', '') }}
 {%-    endif %}

--- a/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_firewall.j2
+++ b/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_firewall.j2
@@ -1,11 +1,12 @@
 {%- for fw, fw_config in provider_config.resources.firewalls.items() %}
 {%-   set fw_tags = [] %}
 {%-   if fw_config.tags %}
-{%-     include 'providers/digitalocean/resources/digitalocean_tag.j2' %}
 {%-     if fw_config.tags %}
 {%-       for tag in fw_config.tags %}
 {%-         set tag_id = 'digitalocean_tag.'+tag|replace('-','_')+'.id' %}
 {%-         set _ = fw_tags.append(tag_id) %}
+{%-         set tag_id_env = 'digitalocean_tag.'+tag|replace('-','_')+'_env.id' %}
+{%-         set _ = fw_tags.append(tag_id_env) %}
 {%-       endfor %}
 {%-     endif %}
 {%-   endif %}

--- a/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_project.j2
+++ b/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_project.j2
@@ -19,9 +19,6 @@ data "digitalocean_project" "{{ proj|replace('-','_') }}" {
 {%-     if proj_config.domains %}
 {%-       include 'providers/digitalocean/resources/digitalocean_domain.j2' %}
 {%-     endif %}
-{%-     if proj_config.tags %}
-{%-       include 'providers/digitalocean/resources/digitalocean_tag.j2' %}
-{%-     endif %}
 {%-     if provider_config.resources.vms %}
 {%-       for vm, vm_config in provider_config.resources.vms.items() %}
 {%-         if vm_config.module == module %}

--- a/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_tag.j2
+++ b/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_tag.j2
@@ -1,18 +1,13 @@
-{%- if fw_config and fw_config.tags %}
-{%-   for tag in fw_config.tags %}
-{%-     if module in fw_config.modules %}
+{%- for tag in provider_config.resources.tags %}
+{%-   if tag not in do_tags %}
 # Resource {{ provider }} tag
 resource "digitalocean_tag" "{{ tag|replace('-','_') }}" {
   name = "{{ tag }}"
 }
-{%-     endif %}
-{%-   endfor %}
-{%- endif %}
-{%- if proj_config and proj_config.tags %}
-{%-   for tag in proj_config.tags %}
 # Resource {{ provider }} tag
-resource "digitalocean_tag" "{{ tag|replace('-','_') }}" {
-  name = "{{ tag }}"
+resource "digitalocean_tag" "{{ tag|replace('-','_')+'_env' }}" {
+  name = format("{{ tag }}-%s", var.environment)
 }
-{%-   endfor %}
-{%- endif %}
+{%-     set _ = do_tags.append(tag) %}
+{%-   endif %}
+{%- endfor %}


### PR DESCRIPTION
DigitalOcean tags are now appropriately added across modules. For every
tag defined, a respective tag will be created for each environment. And
then for each droplet, etc. which can have tags applied will also have a
tag added for the environment as well. This will allow tagging to not
only work for just the defined tag, but also for the tag-environment as
well.

Closes #30