### PR TITLE
A lot of DigitalOcean enhancements here

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -632,9 +632,6 @@ environments:
   production: {}
   staging: {}
 
-# Define global variables
-global_variables: {}
-
 # Define modules - Structure will be project_name/modules/{module}
 # root needs to always exist
 modules:

--- a/examples/configs.yml
+++ b/examples/configs.yml
@@ -26,21 +26,15 @@ environments:
   development:
     variables:
       azurerm_location: East US
-      do_domain: dev.example.org
       do_region: nyc1
   production:
     variables:
       azurerm_location: West US 2
-      do_domain: prd.example.org
-      do_region: sfo1
+      do_region: sfo2
   staging:
     variables:
       azurerm_location: North Central US
-      do_domain: stg.example.org
       do_region: ams3
-
-# Define global variables - Not used at this point
-global_variables: {}
 
 # Define modules - Structure will be project_name/modules/{module}
 # root needs to always exist
@@ -53,18 +47,16 @@ global_variables: {}
 modules:
   root:
     variables:
-      {}
-      # environment: test
+      do_domain: example.org
+      do_ssh_keys: [12121212]
   network:
     variables:
-      {}
-      # environment: test
+      do_domain: network.example.org
+      do_ssh_keys: [12121212]
   services:
-    variables: {}
-
-# Defines default root environment to use for vars.
-# production|staging|development
-default_root_module_env: production
+    variables:
+      do_domain: services.example.org
+      do_ssh_keys: [12121212]
 
 # Define providers and variables
 # For variable definitions, keep the default as undefined and use either modules
@@ -193,25 +185,23 @@ providers:
               port_range: 443
               source_addresses: []
               direction: inbound
+            - protocol: icmp
+              destination_addresses: ["0.0.0.0/0", "::/0"]
+              direction: outbound
             - protocol: tcp
-              port_range: 53
+              port_range: 1-65535
               destination_addresses: ["0.0.0.0/0", "::/0"]
               direction: outbound
             - protocol: udp
-              port_range: 53
+              port_range: 1-65535
               destination_addresses: ["0.0.0.0/0", "::/0"]
               direction: outbound
       projects:
         example:
           create: true
           description: Example project
-          domains:
-            example.org:
-              create: true
           module: root
           purpose: Just to demonstrate an example project
-          tags:
-            - example-digitalocean
       # Define tags that need to be available across all modules. Then you can
       # define the applicable tags to the respective resources. An additional
       # tag will be created that will append each environment to the tag name.
@@ -224,14 +214,17 @@ providers:
       vms:
         # Define firewall to apply, if applicable.
         # Define project to add VM to, if applicable.
+        # Define private networking if you'd like internal addressing. Setting
+        # this to true, will also create an internal domain name if
+        # modules[module]['do_domain'] is defined.
         example-vm:
           count: 1
           firewall: default
           image: ubuntu-18-04-x64
           memory: 1024
           module: root
-          project: example
           num_cpus: 1
+          private_networking: true
           tags:
             - example-digitalocean
     variables:

--- a/examples/example_builds/example/README.md
+++ b/examples/example_builds/example/README.md
@@ -15,17 +15,14 @@ Environments represent such things as: `development`, `staging`, and `production
 development:
   variables:
     azurerm_location: East US
-    do_domain: dev.example.org
     do_region: nyc1
 production:
   variables:
     azurerm_location: West US 2
-    do_domain: prd.example.org
-    do_region: sfo1
+    do_region: sfo2
 staging:
   variables:
     azurerm_location: North Central US
-    do_domain: stg.example.org
     do_region: ams3
 
 ```
@@ -192,25 +189,25 @@ DigitalOcean:
           - 0.0.0.0/0
           - ::/0
           direction: outbound
-          port_range: 53
+          protocol: icmp
+        - destination_addresses:
+          - 0.0.0.0/0
+          - ::/0
+          direction: outbound
+          port_range: 1-65535
           protocol: tcp
         - destination_addresses:
           - 0.0.0.0/0
           - ::/0
           direction: outbound
-          port_range: 53
+          port_range: 1-65535
           protocol: udp
     projects:
       example:
         create: true
         description: Example project
-        domains:
-          example.org:
-            create: true
         module: root
         purpose: Just to demonstrate an example project
-        tags:
-        - example-digitalocean
     tags:
     - default-firewall
     - example-digitalocean
@@ -222,7 +219,7 @@ DigitalOcean:
         memory: 1024
         module: root
         num_cpus: 1
-        project: example
+        private_networking: true
         tags:
         - example-digitalocean
   variables:
@@ -351,18 +348,20 @@ physical objects.
 
 ```yaml
 network:
-  variables: {}
+  variables:
+    do_domain: network.example.org
+    do_ssh_keys:
+    - 12121212
 root:
-  variables: {}
+  variables:
+    do_domain: example.org
+    do_ssh_keys:
+    - 12121212
 services:
-  variables: {}
-
-```
-
-## Global Variables
-
-```yaml
-{}
+  variables:
+    do_domain: services.example.org
+    do_ssh_keys:
+    - 12121212
 
 ```
 

--- a/examples/example_builds/example/environments/development/README.md
+++ b/examples/example_builds/example/environments/development/README.md
@@ -6,7 +6,6 @@
 development:
   variables:
     azurerm_location: East US
-    do_domain: dev.example.org
     do_region: nyc1
 
 ```

--- a/examples/example_builds/example/environments/development/main.tf
+++ b/examples/example_builds/example/environments/development/main.tf
@@ -4,7 +4,6 @@ module "development-root" {
   source      = "../../root"
   environment = "development"
   azurerm_location   = "East US"
-  do_domain   = "dev.example.org"
   do_region   = "nyc1"
 }
 # Module development-network config
@@ -12,7 +11,6 @@ module "development-network" {
   source      = "../../modules/network"
   environment = "development"
   azurerm_location   = "East US"
-  do_domain   = "dev.example.org"
   do_region   = "nyc1"
 }
 # Module development-services config
@@ -20,6 +18,5 @@ module "development-services" {
   source      = "../../modules/services"
   environment = "development"
   azurerm_location   = "East US"
-  do_domain   = "dev.example.org"
   do_region   = "nyc1"
 }

--- a/examples/example_builds/example/environments/production/README.md
+++ b/examples/example_builds/example/environments/production/README.md
@@ -6,8 +6,7 @@
 production:
   variables:
     azurerm_location: West US 2
-    do_domain: prd.example.org
-    do_region: sfo1
+    do_region: sfo2
 
 ```
 

--- a/examples/example_builds/example/environments/production/main.tf
+++ b/examples/example_builds/example/environments/production/main.tf
@@ -4,22 +4,19 @@ module "production-root" {
   source      = "../../root"
   environment = "production"
   azurerm_location   = "West US 2"
-  do_domain   = "prd.example.org"
-  do_region   = "sfo1"
+  do_region   = "sfo2"
 }
 # Module production-network config
 module "production-network" {
   source      = "../../modules/network"
   environment = "production"
   azurerm_location   = "West US 2"
-  do_domain   = "prd.example.org"
-  do_region   = "sfo1"
+  do_region   = "sfo2"
 }
 # Module production-services config
 module "production-services" {
   source      = "../../modules/services"
   environment = "production"
   azurerm_location   = "West US 2"
-  do_domain   = "prd.example.org"
-  do_region   = "sfo1"
+  do_region   = "sfo2"
 }

--- a/examples/example_builds/example/environments/staging/README.md
+++ b/examples/example_builds/example/environments/staging/README.md
@@ -6,7 +6,6 @@
 staging:
   variables:
     azurerm_location: North Central US
-    do_domain: stg.example.org
     do_region: ams3
 
 ```

--- a/examples/example_builds/example/environments/staging/main.tf
+++ b/examples/example_builds/example/environments/staging/main.tf
@@ -4,7 +4,6 @@ module "staging-root" {
   source      = "../../root"
   environment = "staging"
   azurerm_location   = "North Central US"
-  do_domain   = "stg.example.org"
   do_region   = "ams3"
 }
 # Module staging-network config
@@ -12,7 +11,6 @@ module "staging-network" {
   source      = "../../modules/network"
   environment = "staging"
   azurerm_location   = "North Central US"
-  do_domain   = "stg.example.org"
   do_region   = "ams3"
 }
 # Module staging-services config
@@ -20,6 +18,5 @@ module "staging-services" {
   source      = "../../modules/services"
   environment = "staging"
   azurerm_location   = "North Central US"
-  do_domain   = "stg.example.org"
   do_region   = "ams3"
 }

--- a/examples/example_builds/example/modules/network/README.md
+++ b/examples/example_builds/example/modules/network/README.md
@@ -4,7 +4,10 @@
 
 ```yaml
 network:
-  variables: {}
+  variables:
+    do_domain: network.example.org
+    do_ssh_keys:
+    - 12121212
 
 ```
 

--- a/examples/example_builds/example/modules/network/resources.tf
+++ b/examples/example_builds/example/modules/network/resources.tf
@@ -5,7 +5,7 @@ resource "digitalocean_tag" "default_firewall" {
 }
 # Resource DigitalOcean tag
 resource "digitalocean_tag" "default_firewall_env" {
-  name = format("default-firewall-%s", var.environment)
+  name = format("%s", var.environment)
 }
 # Resource DigitalOcean tag
 resource "digitalocean_tag" "example_digitalocean" {
@@ -13,5 +13,13 @@ resource "digitalocean_tag" "example_digitalocean" {
 }
 # Resource DigitalOcean tag
 resource "digitalocean_tag" "example_digitalocean_env" {
-  name = format("example-digitalocean-%s", var.environment)
+  name = format("%s", var.environment)
+}
+# Resource DigitalOcean default domain
+resource "digitalocean_domain" "default_env" {
+  name = format("%s.%s", var.environment, var.do_domain)
+}
+# Resource DigitalOcean default internal domain
+resource "digitalocean_domain" "default_env_internal" {
+  name = format("%s.%s.%s", "internal", var.environment, var.do_domain)
 }

--- a/examples/example_builds/example/modules/network/variables.tf
+++ b/examples/example_builds/example/modules/network/variables.tf
@@ -64,9 +64,7 @@ variable "do_api_endpoint" {
 }
 # Variable do_domain config
 variable "do_domain" {
-    type = string
-    description = "Default DigitalOcean domain for resources"
-    default = ""
+    default = "network.example.org"
 }
 # Variable do_region config
 variable "do_region" {
@@ -76,8 +74,7 @@ variable "do_region" {
 }
 # Variable do_ssh_keys config
 variable "do_ssh_keys" {
-    description = "DigitalOcean SSH keys to deploy to new droplets"
-    default = []
+    default = [12121212]
 }
 # Variable do_token config
 variable "do_token" {

--- a/examples/example_builds/example/modules/services/README.md
+++ b/examples/example_builds/example/modules/services/README.md
@@ -4,7 +4,10 @@
 
 ```yaml
 services:
-  variables: {}
+  variables:
+    do_domain: services.example.org
+    do_ssh_keys:
+    - 12121212
 
 ```
 

--- a/examples/example_builds/example/modules/services/resources.tf
+++ b/examples/example_builds/example/modules/services/resources.tf
@@ -5,7 +5,7 @@ resource "digitalocean_tag" "default_firewall" {
 }
 # Resource DigitalOcean tag
 resource "digitalocean_tag" "default_firewall_env" {
-  name = format("default-firewall-%s", var.environment)
+  name = format("%s", var.environment)
 }
 # Resource DigitalOcean tag
 resource "digitalocean_tag" "example_digitalocean" {
@@ -13,5 +13,13 @@ resource "digitalocean_tag" "example_digitalocean" {
 }
 # Resource DigitalOcean tag
 resource "digitalocean_tag" "example_digitalocean_env" {
-  name = format("example-digitalocean-%s", var.environment)
+  name = format("%s", var.environment)
+}
+# Resource DigitalOcean default domain
+resource "digitalocean_domain" "default_env" {
+  name = format("%s.%s", var.environment, var.do_domain)
+}
+# Resource DigitalOcean default internal domain
+resource "digitalocean_domain" "default_env_internal" {
+  name = format("%s.%s.%s", "internal", var.environment, var.do_domain)
 }

--- a/examples/example_builds/example/modules/services/variables.tf
+++ b/examples/example_builds/example/modules/services/variables.tf
@@ -64,9 +64,7 @@ variable "do_api_endpoint" {
 }
 # Variable do_domain config
 variable "do_domain" {
-    type = string
-    description = "Default DigitalOcean domain for resources"
-    default = ""
+    default = "services.example.org"
 }
 # Variable do_region config
 variable "do_region" {
@@ -76,8 +74,7 @@ variable "do_region" {
 }
 # Variable do_ssh_keys config
 variable "do_ssh_keys" {
-    description = "DigitalOcean SSH keys to deploy to new droplets"
-    default = []
+    default = [12121212]
 }
 # Variable do_token config
 variable "do_token" {

--- a/examples/example_builds/example/root/README.md
+++ b/examples/example_builds/example/root/README.md
@@ -4,7 +4,10 @@
 
 ```yaml
 root:
-  variables: {}
+  variables:
+    do_domain: example.org
+    do_ssh_keys:
+    - 12121212
 
 ```
 

--- a/examples/example_builds/example/root/variables.tf
+++ b/examples/example_builds/example/root/variables.tf
@@ -64,9 +64,7 @@ variable "do_api_endpoint" {
 }
 # Variable do_domain config
 variable "do_domain" {
-    type = string
-    description = "Default DigitalOcean domain for resources"
-    default = ""
+    default = "example.org"
 }
 # Variable do_region config
 variable "do_region" {
@@ -76,8 +74,7 @@ variable "do_region" {
 }
 # Variable do_ssh_keys config
 variable "do_ssh_keys" {
-    description = "DigitalOcean SSH keys to deploy to new droplets"
-    default = []
+    default = [12121212]
 }
 # Variable do_token config
 variable "do_token" {

--- a/examples/example_builds/example/variables.tf
+++ b/examples/example_builds/example/variables.tf
@@ -64,9 +64,7 @@ variable "do_api_endpoint" {
 }
 # Variable do_domain config
 variable "do_domain" {
-    type = string
-    description = "Default DigitalOcean domain for resources"
-    default = ""
+    default = "example.org"
 }
 # Variable do_region config
 variable "do_region" {
@@ -76,8 +74,7 @@ variable "do_region" {
 }
 # Variable do_ssh_keys config
 variable "do_ssh_keys" {
-    description = "DigitalOcean SSH keys to deploy to new droplets"
-    default = []
+    default = [12121212]
 }
 # Variable do_token config
 variable "do_token" {

--- a/terraform_builder/specs/important/templates/README.md.j2
+++ b/terraform_builder/specs/important/templates/README.md.j2
@@ -69,12 +69,6 @@ physical objects.
 {{ args.modules|to_yaml }}
 ```
 
-## Global Variables
-
-```yaml
-{{ args.global_variables|to_yaml }}
-```
-
 ## Project Structure
 
 ```bash

--- a/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean.j2
+++ b/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean.j2
@@ -7,6 +7,9 @@
 {%- if provider_config.resources.vms %}
 {%-   include 'providers/digitalocean/resources/digitalocean_droplet.j2' %}
 {%- endif %}
+{%- set project_resources = [] %}
+{%- include 'providers/digitalocean/resources/digitalocean_domain.j2' %}
+{%- include 'providers/digitalocean/resources/digitalocean_record.j2' %}
 {%- if provider_config.resources.projects %}
 {%-   include 'providers/digitalocean/resources/digitalocean_project.j2' %}
 {%- endif %}

--- a/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_domain.j2
+++ b/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_domain.j2
@@ -1,14 +1,13 @@
-{%- for domain, domain_config in proj_config.domains.items() %}
-{%-   if domain_config.create %}
-# Resource {{ provider }} domain
-resource "digitalocean_domain" "{{ domain|replace('-','_')|replace('.','_') }}" {
-  name = "{{ domain }}"
+
+{%- if args.modules[module]['variables']['do_domain'] %}
+# Resource {{ provider }} default domain
+resource "digitalocean_domain" "default_env" {
+  name = format("%s.%s", var.environment, var.do_domain)
 }
-{%-     set _ = project_resources.append('digitalocean_domain.'+domain|replace('-','_')|replace('.','_')+'.urn') %}
-{%-   else %}
-# Data {{ provider }} domain
-data "digitalocean_domain" "{{ domain|replace('-','_')|replace('.','_') }}" {
-  name = "{{ domain }}"
+{%- set _ = project_resources.append('digitalocean_domain.default_env.urn') %}
+# Resource {{ provider }} default internal domain
+resource "digitalocean_domain" "default_env_internal" {
+  name = format("%s.%s.%s", "internal", var.environment, var.do_domain)
 }
-{%-   endif %}
-{%- endfor %}
+{%- set _ = project_resources.append('digitalocean_domain.default_env_internal.urn') %}
+{%- endif %}

--- a/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_droplet.j2
+++ b/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_droplet.j2
@@ -5,11 +5,12 @@
 # Resource {{ provider }} virtual machine
 resource "digitalocean_droplet" "{{ vm.split('.')[0]|replace('-','_') }}" {
   count    = {{ vm_config.count|default(1) }}
-  name     = format("{{ vm.split('.')[0] }}-%02s-%s", count.index + 1, substr(var.environment, 0, 4))
+  name     = format("{{ vm.split('.')[0] }}-%02s.%s.%s", count.index + 1, var.environment, var.do_domain)
   image    = "{{ vm_config.image }}"
   region   = var.do_region
   size     = "{{ 's-'+cpus+'vcpu-'+memory+'gb' }}"
   ssh_keys = var.do_ssh_keys
+  private_networking = {{ vm_config.private_networking|default(false)|lower }}
 {%-    if vm_config.tags %}
 {%-      set tags = [] %}
 {%-      for tag in vm_config.tags %}

--- a/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_firewall.j2
+++ b/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_firewall.j2
@@ -23,7 +23,7 @@
 {%-     endif %}
 # Resource {{ provider }} firewall
 resource "digitalocean_firewall" "{{ fw|replace('-','_') }}" {
-  name = format("{{ fw_config.name }}-%s", var.environment)
+  name = format("{{ fw_config.name+'-'+module }}-%s", var.environment)
 {%-     if fw_resources != [] %}
   droplet_ids = concat({{ fw_resources|join(', ') }})
 {%-     endif %}
@@ -33,7 +33,9 @@ resource "digitalocean_firewall" "{{ fw|replace('-','_') }}" {
 {%-       if rule.direction == 'inbound' %}
   inbound_rule {
     protocol         = "{{ rule.protocol }}"
+{%-         if rule.port_range %}
     port_range       = "{{ rule.port_range }}"
+{%-         endif %}
     source_addresses = {{ rule.source_addresses|replace('\'','"') }}
   }
 {%-       elif rule.direction == 'outbound' %}

--- a/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_project.j2
+++ b/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_project.j2
@@ -1,10 +1,9 @@
 {%- for proj, proj_config in provider_config.resources.projects.items() %}
 {%-   if proj_config.module == module %}
-{%-     set project_resources = [] %}
 {%-     if proj_config.create %}
 # Resource {{ provider }} project
 resource "digitalocean_project" "{{ proj|replace('-','_') }}" {
-  name        = format("{{ proj }}-%s", substr(var.environment, 0, 4))
+  name        = format("{{ proj }}-%s", var.environment)
   description = format("{{ proj_config.description }} - %s", var.environment)
   purpose     = format("{{ proj_config.purpose }} - %s", var.environment)
   environment = var.environment
@@ -13,18 +12,13 @@ resource "digitalocean_project" "{{ proj|replace('-','_') }}" {
 {%-     else %}
 # Data {{ provider }} project
 data "digitalocean_project" "{{ proj|replace('-','_') }}" {
-  name        = format("{{ proj }}-%s", substr(var.environment, 0, 4))
+  name        = format("{{ proj }}-%s", var.environment)
 }
-{%-     endif %}
-{%-     if proj_config.domains %}
-{%-       include 'providers/digitalocean/resources/digitalocean_domain.j2' %}
 {%-     endif %}
 {%-     if provider_config.resources.vms %}
 {%-       for vm, vm_config in provider_config.resources.vms.items() %}
 {%-         if vm_config.module == module %}
-{%-           if vm_config.project and vm_config.project == proj %}
-{%-             set _ = project_resources.append('digitalocean_droplet.'+vm.split('.')[0]|replace('-','_')+'.*.urn') %}
-{%-           endif %}
+{%-           set _ = project_resources.append('digitalocean_droplet.'+vm.split('.')[0]|replace('-','_')+'.*.urn') %}
 {%-         endif %}
 {%-       endfor %}
 {%-     endif %}

--- a/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_record.j2
+++ b/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_record.j2
@@ -1,0 +1,15 @@
+
+{%- for vm, vm_config in provider_config.resources.vms.items() %}
+{%-   if vm_config.module == module %}
+{%-     if vm_config.private_networking %}
+# Resource {{ provider }} internal DNS record
+resource "digitalocean_record" "{{ (vm.split('.')[0]|replace('-','_'))+'_internal' }}" {
+  count  = {{ vm_config.count }}
+  domain = format("%s.%s.%s", "internal", var.environment, var.do_domain)
+  type   = "A"
+  name   = format("{{ vm.split('.')[0]|replace('-','_') }}-%02s", count.index + 1)
+  value  = digitalocean_droplet.{{ vm.split('.')[0]|replace('-','_') }}[count.index].ipv4_address_private
+}
+{%-     endif %}
+{%-   endif %}
+{%- endfor %}

--- a/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_tag.j2
+++ b/terraform_builder/specs/templates/providers/digitalocean/resources/digitalocean_tag.j2
@@ -6,7 +6,7 @@ resource "digitalocean_tag" "{{ tag|replace('-','_') }}" {
 }
 # Resource {{ provider }} tag
 resource "digitalocean_tag" "{{ tag|replace('-','_')+'_env' }}" {
-  name = format("{{ tag }}-%s", var.environment)
+  name = format("%s", var.environment)
 }
 {%-     set _ = do_tags.append(tag) %}
 {%-   endif %}


### PR DESCRIPTION
This PR will:
- Closes #32
- Closes #33
- Closes #34

There are a lot of DigitalOcean enhancements here. Including:
- Domains managed when defining in modules[module]['do_domain']
- Internal domain "internal.modules[module]['do_domain'] added for
  internal communications
- Internal DNS A record for VMs when private_networking: true
- Firewall rules now named with module name appended to get around
  duplicated rule names when multiple modules consume the firewall
- Droplet names now have environment and domain appended to create a
  FQDN name for VM
- Tag added to droplets for environment by default