### PR TITLE
Added environment index variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+commit dc4ed34e4554ac600a238502787f621d1802c194
+Author: Larry Smith Jr <mrlesmithjr@gmail.com>
+Date:   Thu Apr 2 12:30:10 2020 -0400
+
+    First commit of more useful docs
+    
+    Closes #38
+
+commit dbcaf3888256313ed8bc6dd0744b5d22e6ae6be6
+Author: Larry Smith Jr <mrlesmithjr@gmail.com>
+Date:   Wed Apr 1 17:25:28 2020 -0400
+
+    Updated examples to show var usage for vSphere in environments
+    
+    Example updated to demonstrate how to define vSphere vars differently
+    between environments.
+
+commit 393a2abc2ab5f2a11d22b6c881b3bfbf39d7dfa9
+Author: Larry Smith Jr <mrlesmithjr@gmail.com>
+Date:   Wed Apr 1 15:42:03 2020 -0400
+
+    First commit to address vSphere issues
+    
+    This is to address #41
+
 commit fbbbd1acff91563da05be2dbb4139a6bdf09908a
 Author: Larry Smith Jr <mrlesmithjr@gmail.com>
 Date:   Wed Apr 1 09:25:09 2020 -0400

--- a/examples/example_builds/example/environments/development/variables.tf
+++ b/examples/example_builds/example/environments/development/variables.tf
@@ -4,6 +4,11 @@ variable "environment" {
     type = string
     default = ""
 }
+# Variable environment_index config
+variable "environment_index" {
+    type = number
+    default = "0"
+}
 # Variable azurerm_client_id config
 variable "azurerm_client_id" {
     type = string

--- a/examples/example_builds/example/environments/production/variables.tf
+++ b/examples/example_builds/example/environments/production/variables.tf
@@ -4,6 +4,11 @@ variable "environment" {
     type = string
     default = ""
 }
+# Variable environment_index config
+variable "environment_index" {
+    type = number
+    default = "0"
+}
 # Variable azurerm_client_id config
 variable "azurerm_client_id" {
     type = string

--- a/examples/example_builds/example/environments/staging/variables.tf
+++ b/examples/example_builds/example/environments/staging/variables.tf
@@ -4,6 +4,11 @@ variable "environment" {
     type = string
     default = ""
 }
+# Variable environment_index config
+variable "environment_index" {
+    type = number
+    default = "0"
+}
 # Variable azurerm_client_id config
 variable "azurerm_client_id" {
     type = string

--- a/examples/example_builds/example/main.tf
+++ b/examples/example_builds/example/main.tf
@@ -4,18 +4,21 @@
 
 # Module development config
 module "development" {
-  source      = "./environments/development"
-  environment = "development"
+  source            = "./environments/development"
+  environment       = "development"
+  environment_index = 1
 }
 # Module production config
 module "production" {
-  source      = "./environments/production"
-  environment = "production"
+  source            = "./environments/production"
+  environment       = "production"
+  environment_index = 2
 }
 # Module staging config
 module "staging" {
-  source      = "./environments/staging"
-  environment = "staging"
+  source            = "./environments/staging"
+  environment       = "staging"
+  environment_index = 3
 }
 # Generated using https://github.com/mrlesmithjr/terraform-builder
 

--- a/examples/example_builds/example/modules/network/variables.tf
+++ b/examples/example_builds/example/modules/network/variables.tf
@@ -4,6 +4,11 @@ variable "environment" {
     type = string
     default = ""
 }
+# Variable environment_index config
+variable "environment_index" {
+    type = number
+    default = "0"
+}
 # Variable azurerm_client_id config
 variable "azurerm_client_id" {
     type = string

--- a/examples/example_builds/example/modules/services/variables.tf
+++ b/examples/example_builds/example/modules/services/variables.tf
@@ -4,6 +4,11 @@ variable "environment" {
     type = string
     default = ""
 }
+# Variable environment_index config
+variable "environment_index" {
+    type = number
+    default = "0"
+}
 # Variable azurerm_client_id config
 variable "azurerm_client_id" {
     type = string

--- a/examples/example_builds/example/root/variables.tf
+++ b/examples/example_builds/example/root/variables.tf
@@ -4,6 +4,11 @@ variable "environment" {
     type = string
     default = ""
 }
+# Variable environment_index config
+variable "environment_index" {
+    type = number
+    default = "0"
+}
 # Variable azurerm_client_id config
 variable "azurerm_client_id" {
     type = string

--- a/examples/example_builds/example/variables.tf
+++ b/examples/example_builds/example/variables.tf
@@ -4,6 +4,11 @@ variable "environment" {
     type = string
     default = ""
 }
+# Variable environment_index config
+variable "environment_index" {
+    type = number
+    default = "0"
+}
 # Variable azurerm_client_id config
 variable "azurerm_client_id" {
     type = string

--- a/terraform_builder/specs/templates/project_root/environments.j2
+++ b/terraform_builder/specs/templates/project_root/environments.j2
@@ -1,7 +1,8 @@
 {%-  for environment in args.environments %}
 # Module {{ environment }} config
 module "{{ environment }}" {
-  source      = "./environments/{{ environment }}"
-  environment = "{{ environment }}"
+  source            = "./environments/{{ environment }}"
+  environment       = "{{ environment }}"
+  environment_index = {{ loop.index }}
 }
 {%-  endfor %}

--- a/terraform_builder/specs/templates/variables/variables.tf.j2
+++ b/terraform_builder/specs/templates/variables/variables.tf.j2
@@ -1,6 +1,6 @@
 # Generated using https://github.com/mrlesmithjr/terraform-builder
 {%- set vars = {} %}
-{%- set _ = vars.update({'environment': {'type': 'string', 'default': ''}}) %}
+{%- set _ = vars.update({'environment': {'type': 'string', 'default': ''},'environment_index': {'type': 'number','default': 0}}) %}
 {%- for provider, provider_config in args.providers.items() %}
 {%-   if provider_config != {} -%}
 {%-     if provider_config['variables'] -%}


### PR DESCRIPTION
This variable will be added automatically on the backend configurations.
This will be something that we can tap into using between each
environment: development, production, and staging. For example, static
IP addresses could be defined by cidrhost("10.0.0.0/16", count.index +
var.environment_index). This might need to be tweaked a bit as more
testing occurs.

Closes #44 