### PR TITLE
Fixed var list quotes

### DIFF
--- a/terraform_builder/specs/templates/variables/variables.tf.j2
+++ b/terraform_builder/specs/templates/variables/variables.tf.j2
@@ -26,7 +26,7 @@ variable "{{ variable }}" {
     {{ key }} = {{ value }}
 {%-         else %}
 {%-           if value is iterable and value is not string and value is not mapping  %}
-    {{ key }} = {{ value }}
+    {{ key }} = {{ value|replace('\'', '\"') }}
 {%-           elif value is mapping %}
     {{ key }} = {{ value|replace('\'', '\"') }}
 {%-           else %}


### PR DESCRIPTION
When a var was defined as a list, the resulting configuration would be
single quoted rather than double quoted.