### PR TITLE
Removed DO Tag Resources

### DIFF
--- a/docs/02_configuration/guide.md
+++ b/docs/02_configuration/guide.md
@@ -344,15 +344,6 @@ providers:
           description: Example project
           module: root
           purpose: Just to demonstrate an example project
-      # Define tags that need to be available across all modules. Then you can
-      # define the applicable tags to the respective resources. An additional
-      # tag will be created that will append each environment to the tag name.
-      # Ex. example-digitalocean-development, example-digitalocean-production,
-      # example-digitalocean-staging. Resources with tags defined will also be
-      # add to the tag with the environment as well.
-      tags:
-        - default-firewall
-        - example-digitalocean
       vms:
         # Define firewall to apply, if applicable.
         # Define project to add VM to, if applicable.

--- a/examples/configs.yml
+++ b/examples/configs.yml
@@ -314,15 +314,6 @@ providers:
           description: Example project
           module: root
           purpose: Just to demonstrate an example project
-      # Define tags that need to be available across all modules. Then you can
-      # define the applicable tags to the respective resources. An additional
-      # tag will be created that will append each environment to the tag name.
-      # Ex. example-digitalocean-development, example-digitalocean-production,
-      # example-digitalocean-staging. Resources with tags defined will also be
-      # add to the tag with the environment as well.
-      tags:
-        - default-firewall
-        - example-digitalocean
       vms:
         # Define firewall to apply, if applicable.
         # Define project to add VM to, if applicable.

--- a/examples/example_builds/example/README.md
+++ b/examples/example_builds/example/README.md
@@ -280,9 +280,6 @@ DigitalOcean:
         description: Example project
         module: root
         purpose: Just to demonstrate an example project
-    tags:
-    - default-firewall
-    - example-digitalocean
     vms:
       example-vm:
         backups: false


### PR DESCRIPTION
Because we no longer require tags to be defined under resources, these
can be removed. Tags are defined at the resource instead. For example,
vms (droplets) and firewalls.